### PR TITLE
cargo clippy warnings

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -35,8 +35,8 @@ pub struct ConnectionState {
 impl ConnectionState {
     pub fn get_payload(&self) -> String {
         match &self.hmac_payload {
-            Some(payload) => return payload.clone(),
-            None => return "".to_string(),
+            Some(payload) => payload.clone(),
+            None => "".to_string(),
         }
     }
     pub fn new() -> ConnectionState {
@@ -149,7 +149,7 @@ impl Connection {
                         //TODO: Determine what needs to happen here
                     }
                     //this command is where we tell the client what port to use
-                    //WARNING: This command does not work properly. 
+                    //WARNING: This command does not work properly.
                     //For some reason the client does not like the port we are sending and defaults to 65535 this is fine for now but will be fixed in the future
                     Some(FtlCommand::Dot) => {
                         let resp_string = "200 hi. Use UDP port 10170\n".to_string();
@@ -188,7 +188,7 @@ async fn handle_frame_command(
         Some(FrameCommand::Send { data }) => {
             let mut d: Vec<String> = data.clone();
             d.reverse();
-            while d.len() != 0 {
+            while !d.is_empty() {
                 let item = d.pop().unwrap();
                 match frame.send(item.clone()).await {
                     Ok(_) => {}
@@ -337,8 +337,8 @@ async fn handle_command(
                         ),
                     }
                 }
-                (None, Some(value)) => {}
-                (Some(key), None) => {}
+                (None, Some(_value)) => {}
+                (Some(_key), None) => {}
                 (None, None) => {}
             }
         }

--- a/src/ftl_codec.rs
+++ b/src/ftl_codec.rs
@@ -42,36 +42,36 @@ impl Decoder for FtlCodec {
                 buf.advance(index + 4);
                 if command.as_str().contains("HMAC") {
                     self.reset();
-                    return Ok(Some(FtlCommand::HMAC));
+                    Ok(Some(FtlCommand::HMAC))
                 } else if command.as_str().contains("DISCONNECT") {
                     self.reset();
-                    return Ok(Some(FtlCommand::Disconnect));
+                    Ok(Some(FtlCommand::Disconnect))
                 } else if command.as_str().contains("CONNECT") {
-                    let commands: Vec<&str> = command.split(" ").collect();
+                    let commands: Vec<&str> = command.split(' ').collect();
                     let mut key = commands[2].to_string();
                     key.remove(0);
                     data.insert("channel_id".to_string(), commands[1].to_string());
                     data.insert("stream_key".to_string(), key);
                     self.reset();
-                    return Ok(Some(FtlCommand::Connect { data }));
-                } else if command.as_str().contains(":") {
-                    let commands: Vec<&str> = command.split(":").collect();
+                    Ok(Some(FtlCommand::Connect { data }))
+                } else if command.as_str().contains(':') {
+                    let commands: Vec<&str> = command.split(':').collect();
                     data.insert("key".to_string(), commands[0].to_string());
                     data.insert("value".to_string(), commands[1].trim().to_string());
                     self.reset();
-                    return Ok(Some(FtlCommand::Attribute { data }));
-                } else if command.as_str().contains(".") && command.len() == 1 {
+                    Ok(Some(FtlCommand::Attribute { data }))
+                } else if command.as_str().contains('.') && command.len() == 1 {
                     self.reset();
-                    return Ok(Some(FtlCommand::Dot));
+                    Ok(Some(FtlCommand::Dot))
                 } else if command.as_str().contains("PING") {
                     self.reset();
-                    return Ok(Some(FtlCommand::Ping));
+                    Ok(Some(FtlCommand::Ping))
                 } else {
                     self.reset();
-                    return Err(FtlError::Unsupported(command));
+                    Err(FtlError::Unsupported(command))
                 }
             }
-            None => return Ok(None),
+            None => Ok(None),
         }
     }
 }


### PR DESCRIPTION
[cargo clippy](https://github.com/rust-lang/rust-clippy) is a really useful
linting tool, though most of these are small, rust-like nuances. It is always
configurable if some of these aren't your desired style.

- unused variables
- unneeded returns
- single-character string constant

```
warning: unused variable: `value`
   --> src/connection.rs:340:29
    |
340 |                 (None, Some(value)) => {}
    |                             ^^^^^ help: if this is intentional, prefix it with an underscore: `_value`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `key`
   --> src/connection.rs:341:23
    |
341 |                 (Some(key), None) => {}
    |                       ^^^ help: if this is intentional, prefix it with an underscore: `_key`

warning: variant is never constructed: `Kill`
  --> src/connection.rs:14:5
   |
14 |     Kill,
   |     ^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: variant is never constructed: `ConnectionClosed`
  --> src/ftl_codec.rs:93:5
   |
93 |     ConnectionClosed,
   |     ^^^^^^^^^^^^^^^^

warning: variant is never constructed: `CommandNotFound`
  --> src/ftl_codec.rs:95:5
   |
95 |     CommandNotFound,
   |     ^^^^^^^^^^^^^^^

warning: unneeded `return` statement
  --> src/connection.rs:38:30
   |
38 |             Some(payload) => return payload.clone(),
   |                              ^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `payload.clone()`
   |
   = note: `#[warn(clippy::needless_return)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/connection.rs:39:21
   |
39 |             None => return "".to_string(),
   |                     ^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `"".to_string()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: length comparison to zero
   --> src/connection.rs:191:19
    |
191 |             while d.len() != 0 {
    |                   ^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!d.is_empty()`
    |
    = note: `#[warn(clippy::len_zero)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: unneeded `return` statement
  --> src/ftl_codec.rs:45:21
   |
45 |                     return Ok(Some(FtlCommand::HMAC));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Ok(Some(FtlCommand::HMAC))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/ftl_codec.rs:48:21
   |
48 |                     return Ok(Some(FtlCommand::Disconnect));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Ok(Some(FtlCommand::Disconnect))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/ftl_codec.rs:56:21
   |
56 |                     return Ok(Some(FtlCommand::Connect { data }));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Ok(Some(FtlCommand::Connect { data }))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/ftl_codec.rs:62:21
   |
62 |                     return Ok(Some(FtlCommand::Attribute { data }));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Ok(Some(FtlCommand::Attribute { data }))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/ftl_codec.rs:65:21
   |
65 |                     return Ok(Some(FtlCommand::Dot));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Ok(Some(FtlCommand::Dot))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/ftl_codec.rs:68:21
   |
68 |                     return Ok(Some(FtlCommand::Ping));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Ok(Some(FtlCommand::Ping))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/ftl_codec.rs:71:21
   |
71 |                     return Err(FtlError::Unsupported(command));
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove `return`: `Err(FtlError::Unsupported(command))`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: unneeded `return` statement
  --> src/ftl_codec.rs:74:21
   |
74 |             None => return Ok(None),
   |                     ^^^^^^^^^^^^^^^ help: remove `return`: `Ok(None)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

warning: single-character string constant used as pattern
  --> src/ftl_codec.rs:50:61
   |
50 |                     let commands: Vec<&str> = command.split(" ").collect();
   |                                                             ^^^ help: try using a `char` instead: `' '`
   |
   = note: `#[warn(clippy::single_char_pattern)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
  --> src/ftl_codec.rs:57:53
   |
57 |                 } else if command.as_str().contains(":") {
   |                                                     ^^^ help: try using a `char` instead: `':'`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
  --> src/ftl_codec.rs:58:61
   |
58 |                     let commands: Vec<&str> = command.split(":").collect();
   |                                                             ^^^ help: try using a `char` instead: `':'`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: single-character string constant used as pattern
  --> src/ftl_codec.rs:63:53
   |
63 |                 } else if command.as_str().contains(".") && command.len() == 1 {
   |                                                     ^^^ help: try using a `char` instead: `'.'`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern

warning: 20 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 10.47s
```

Neat project :)
