### PR TITLE
Build in release mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust
 WORKDIR /rust/src/
 RUN git clone https://github.com/GRVYDEV/Lightspeed-ingest.git
 WORKDIR /rust/src/Lightspeed-ingest
-RUN cargo build
+RUN cargo build --release
 
 EXPOSE 8084
 


### PR DESCRIPTION
When `cargo build` and `cargo run` use different compilation flags, they don't share a cache, which means that `run` ends up re-building from scratch every time.