### PR TITLE
Use local directory for Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+target/
+Dockerfile
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM rust
+FROM rust:latest as builder
 
 WORKDIR /rust/src/
-RUN git clone https://github.com/GRVYDEV/Lightspeed-ingest.git
-WORKDIR /rust/src/Lightspeed-ingest
-RUN cargo build --release
+
+COPY . .
+
+RUN cargo install --path .
+
+FROM debian:buster-slim
+
+COPY --from=builder /usr/local/cargo/bin/lightspeed-ingest /usr/local/bin/lightspeed-ingest
 
 EXPOSE 8084
 
-CMD cargo run --release
+CMD ["lightspeed-ingest"]


### PR DESCRIPTION
I've also cleaned up the dockerfile a bit, to allow for a multi-stage build that only keeps the final binary in the image (no source code). This will make the image much smaller.

Fixes #20 .