### PR TITLE
WIP: Auto-generate stream key at first start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 #Added by cargo
 
 /target
+hash

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // TODO: fix double reading stream key
+    let _: String = connection::read_stream_key();
+
     println!("Listening on port 8084");
     let listener = TcpListener::bind("0.0.0.0:8084").await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,7 @@ use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // TODO: fix double reading stream key
-    let _: String = connection::read_stream_key();
+    let _ = connection::read_stream_key(true);
 
     println!("Listening on port 8084");
     let listener = TcpListener::bind("0.0.0.0:8084").await?;


### PR DESCRIPTION
Fixes #11. Extremely basic stream-key generation:
- `stream_key` is generated at first launch and **saved as plaintext**
- subsequent launches just pull the key from the file on disk
