### PR TITLE
Run docker container in /data, so we can easily save data there

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ FROM debian:buster-slim
 
 COPY --from=builder /usr/local/cargo/bin/lightspeed-ingest /usr/local/bin/lightspeed-ingest
 
+RUN mkdir /data
+
 EXPOSE 8084
+
+WORKDIR /data
 
 CMD ["lightspeed-ingest"]


### PR DESCRIPTION
To have a good Docker support, we should run the daemon in `/data` so that the stream key from #24 can persist between containers, utilizing docker volumes.
