### PR TITLE
Add command line support. Add flag and env var support to allow specifying listening address.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bumpalo"
@@ -44,6 +70,22 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+ "yaml-rust",
+]
 
 [[package]]
 name = "futures"
@@ -201,6 +243,7 @@ name = "lightspeed-ingest"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "clap",
  "futures",
  "futures-util",
  "hex",
@@ -507,6 +550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "syn"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +564,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -584,6 +642,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +658,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"
@@ -686,3 +756,9 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bytes = "1.0.0"
+clap = {version = "2.33.3", features = ["yaml"]}
+futures = "0.3.8"
+futures-util = "0.3.8"
+hex = "0.4.2"
+rand = "0.8.1"
+regex = "1"
+ring = "0.16.19"
+rtp-rs = "0.5.0"
 tokio = { version = "1.0.1", features = ["full"] }
 tokio-util = { version = "0.6.0", features = ["codec"] }
-bytes = "1.0.0"
-futures = "0.3.8"
-rand = "0.8.1"
-hex = "0.4.2"
-futures-util = "0.3.8"
-ring = "0.16.19"
-regex = "1"
-rtp-rs = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ To run it with default settings type the following command.
 cargo run --release
 ```
 
-To specify an address and/or port
+To specify which address to bind to.
 
 ```sh
-cargo run --release -- -a 12.34.56.78 -p 8084
+cargo run --release -- -a 12.34.56.78
 ```
 
 <!-- _For more examples, please refer to the [Documentation](https://example.com)_ -->

--- a/README.md
+++ b/README.md
@@ -97,13 +97,22 @@ cargo build
 <!-- USAGE EXAMPLES -->
 
 ## Usage
-
-To run type the following command. 
+To print out full command line usage information.
 
 ```sh
-cd Lightspeed-ingest
-cargo run --release
+cargo run -- -h
+```
 
+To run it with default settings type the following command. 
+
+```sh
+cargo run --release
+```
+
+To specify an address and/or port
+
+```sh
+cargo run --release -- -a 12.34.56.78 -p 8084
 ```
 
 <!-- _For more examples, please refer to the [Documentation](https://example.com)_ -->

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,0 +1,19 @@
+name: Lightspeed Ingest
+version: "0.1.0"
+author: "Garrett Graves <gravesg57@gmail.com>"
+about: "A FTL handshake server written in Rust"
+args:
+    - address:
+        short: a
+        long: address
+        env: LS_INGEST_ADDR
+        value_name: HOSTNAME_OR_IP
+        help: Specify which address to bind to (defaults to 0.0.0.0)
+        takes_value: true
+    - port:
+        short: p
+        long: port
+        env: LS_INGEST_PORT
+        value_name: PORT
+        help: Specify which port to use (defaults to 8084)
+        takes_value: true

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -10,10 +10,3 @@ args:
         value_name: HOSTNAME_OR_IP
         help: Specify which address to bind to (defaults to 0.0.0.0)
         takes_value: true
-    - port:
-        short: p
-        long: port
-        env: LS_INGEST_PORT
-        value_name: PORT
-        help: Specify which port to use (defaults to 8084)
-        takes_value: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,51 @@
+#[macro_use]
+extern crate clap;
+use clap::App;
+
 mod connection;
 mod ftl_codec;
 use tokio::net::TcpListener;
 
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("Listening on port 8084");
-    let listener = TcpListener::bind("0.0.0.0:8084").await?;
+    let default_bind_address = "0.0.0.0";
+    let default_port = "8084";
+
+    // update cli.yml to add more flags
+    let cli_cfg = load_yaml!("cli.yml");
+    let matches = App::from_yaml(cli_cfg).get_matches();
+
+    // Find an address and port to bind to. The search order is as follows:
+    // 1.) command line argument
+    // 2.) environment variables (INGEST_ADDR and INGEST_PORT)
+    // 3.) Default to 0.0.0.0 and 8084
+    let bind_address: &str = match matches.value_of("address") {
+        Some(addr) => {
+            if addr.is_empty() {
+                default_bind_address
+            }
+            else {
+                addr
+            }
+        }
+        None => default_bind_address
+    };
+
+    let port: &str = match matches.value_of("port") {
+        Some(port) => {
+            if port.is_empty() {
+                default_port
+            }
+            else {
+                port
+            }
+        }
+        None => default_port
+    };
+
+    println!("Listening on {} port {}", bind_address, port);
+    let listener = TcpListener::bind(format!("{}:{}", bind_address, port)).await?;
 
     loop {
         // Wait until someone tries to connect then handle the connection in a new task

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use tokio::net::TcpListener;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let default_bind_address = "0.0.0.0";
-    let default_port = "8084";
 
     // update cli.yml to add more flags
     let cli_cfg = load_yaml!("cli.yml");
@@ -18,8 +17,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Find an address and port to bind to. The search order is as follows:
     // 1.) command line argument
-    // 2.) environment variables (INGEST_ADDR and INGEST_PORT)
-    // 3.) Default to 0.0.0.0 and 8084
+    // 2.) environment variable (LS_INGEST_ADDR)
+    // 3.) Default to 0.0.0.0
     let bind_address: &str = match matches.value_of("address") {
         Some(addr) => {
             if addr.is_empty() {
@@ -32,20 +31,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => default_bind_address
     };
 
-    let port: &str = match matches.value_of("port") {
-        Some(port) => {
-            if port.is_empty() {
-                default_port
-            }
-            else {
-                port
-            }
-        }
-        None => default_port
-    };
-
-    println!("Listening on {} port {}", bind_address, port);
-    let listener = TcpListener::bind(format!("{}:{}", bind_address, port)).await?;
+    println!("Listening on {} port 8084", bind_address);
+    let listener = TcpListener::bind(format!("{}:8084", bind_address)).await?;
 
     loop {
         // Wait until someone tries to connect then handle the connection in a new task


### PR DESCRIPTION
Alphabetized dependency list.

Added flags:
 -h, --help flag to show usage info.
 -a, --address flag to allow specifying an address to bind to.
 -p, --port flag to allow specifying a port to listen on.

Added support for environment variables for address and port (LS_INGEST_ADDR and LS_INGEST_PORT, respectively).

All new flags can be added to src/cli.yml

The search order for address and port:
1.) Command line argument
2.) Environment variables (INGEST_ADDR and INGEST_PORT)
3.) Default to 0.0.0.0 and 8084

