### PR TITLE
Change logging to use SimpleLogger if TermLogger is not available

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => default_bind_address,
     };
 
-    let mut loggers: Vec<Box<dyn SharedLogger>> =
-        vec![TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed).unwrap()];
+    let mut loggers: Vec<Box<dyn SharedLogger>> = vec![];
+    loggers.push(match TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed) {
+        Some(termlogger) => termlogger,
+        None => SimpleLogger::new(LevelFilter::Info, Config::default()),
+    });
     match matches.value_of("log-file") {
         Some(path) => {
             if !path.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,10 +34,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let mut loggers: Vec<Box<dyn SharedLogger>> = vec![];
-    loggers.push(match TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed) {
-        Some(termlogger) => termlogger,
-        None => SimpleLogger::new(LevelFilter::Info, Config::default()),
-    });
+    loggers.push(
+        match TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed) {
+            Some(termlogger) => termlogger,
+            None => SimpleLogger::new(LevelFilter::Info, Config::default()),
+        },
+    );
     match matches.value_of("log-file") {
         Some(path) => {
             if !path.is_empty() {


### PR DESCRIPTION
According to [https://github.com/Drakulix/simplelog.rs/issues/4](https://github.com/Drakulix/simplelog.rs/issues/4), TermLogger does not work within systemd services, so the "unwrap" call fails. Here is the proposed solution from the simplelog issue (as far as I understand a fallback to SimpleLogger if TermLogger fails).