### PR TITLE
Remove dependency on debian:buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,18 @@ FROM rust:latest as builder
 
 WORKDIR /rust/src/
 
+RUN apt update && apt install -y musl-tools
+RUN rustup target add x86_64-unknown-linux-musl
+
 COPY . .
 
-RUN cargo install --path .
+RUN RUST_BACKTRACE=1 cargo install --target x86_64-unknown-linux-musl --path .
+RUN mkdir /data
 
-FROM debian:buster-slim
+FROM scratch
 
 COPY --from=builder /usr/local/cargo/bin/lightspeed-ingest /usr/local/bin/lightspeed-ingest
-
-RUN mkdir /data
+COPY --from=builder /data /data
 
 EXPOSE 8084
 


### PR DESCRIPTION
Since there are actually no external lib dependencies, you don't need a base image with any underlying OS.
Sounds crazy, but from my initial testing it works, and cuts the Docker image size from ~30MB to ~2MB.

The same can also be done for lightspeed-webrtc, though you need to make Go statically link its libraries.