### PR TITLE
STREAM KEY as environment variable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ target/
 Dockerfile
 README.md
 LICENSE
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
 FROM rust:latest as builder
-
 WORKDIR /rust/src/
-
 COPY . .
-
 RUN cargo install --path .
 
-FROM debian:buster-slim
 
-COPY --from=builder /usr/local/cargo/bin/lightspeed-ingest /usr/local/bin/lightspeed-ingest
+FROM debian:buster-slim as lightspeed-ingest
+RUN useradd -M -s /bin/bash lightspeed
+WORKDIR /data
+RUN chown lightspeed:root /data
+COPY --from=builder --chown=lightspeed:lightspeed /usr/local/cargo/bin/lightspeed-ingest /usr/local/bin/lightspeed-ingest
 
-RUN mkdir /data
+USER lightspeed
+CMD ["lightspeed-ingest"]
 
 EXPOSE 8084
-
-WORKDIR /data
-
-CMD ["lightspeed-ingest"]

--- a/README.md
+++ b/README.md
@@ -149,7 +149,14 @@ After restarting OBS you should be able to see your service in the OBS settings 
 
 
 ### Stream Key
-We are no longer using a default streamkey! If you are still using one please pull from master on the Lightspeed-ingest repository. Now, by default on first time startup a new streamkey will be generated and output to the terminal for you. In order to regenerate this key simply delete the file it generates called `hash`. In a Docker context we will work to make the key reset process as easy as possible. Simply copy the key output in the terminal to OBS and you are all set! This key WILL NOT change unless the `hash` file is deleted.
+By default on first time startup a new stream key will be generated and output to the terminal for you. In order 
+to regenerate this key simply delete the file it generates called `hash`. Simply copy the key output in the terminal 
+to OBS and you are all set! This key WILL NOT change unless the `hash` file is deleted.
+
+You can assign a static key by passing `--stream-key mykey` or via environment variable `STREAM_KEY=mykey`. If you 
+assign it manually it will become prefixed with `77-` so the result will be `77-mykey`. You can verify this in the boot 
+logs.
+
 
 <img src="images/streamkey-example.png" alt="Streamkey example">
 

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -10,6 +10,14 @@ args:
         value_name: HOSTNAME_OR_IP
         help: Specify which address to bind to (defaults to 0.0.0.0)
         takes_value: true
+
+    - stream-key:
+        short: k
+        long: stream-key
+        env: STREAM_KEY
+        value_name: STREAM_KEY
+        help: Optionally set a static Stream Key (will be prefixed with "77-")
+        takes_value: true
     
     # Optional path to the log file, creates a simplelog::WriteLogger
     - log-file:

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -236,8 +236,7 @@ async fn handle_command(
                 (Some(key), Some(_channel_id)) => {
                     //decode the client hash
                     let client_hash = hex::decode(key).expect("error with hash decode");
-                    let key = hmac::Key::new(hmac::HMAC_SHA512,
-                                             &read_stream_key(false, Some("")));
+                    let key = hmac::Key::new(hmac::HMAC_SHA512, &read_stream_key(false, Some("")));
                     //compare the two hashes to ensure they match
                     match hmac::verify(
                         &key,
@@ -383,16 +382,16 @@ fn print_stream_key(stream_key: Vec<u8>) {
 
 pub fn read_stream_key(startup: bool, stream_key_env: Option<&str>) -> Vec<u8> {
     if startup {
-        if !stream_key_env.is_none() {
-            let stream_key = stream_key_env.unwrap().to_string();
+        if let Some(stream_key) = stream_key_env {
             if !stream_key.is_empty() {
                 let key = stream_key.as_bytes().to_vec();
                 print_stream_key(key.to_vec());
-                fs::write("hash", hex::encode(&stream_key)).expect("Unable to write file");
-                return key
+                fs::write("hash", hex::encode(&stream_key))
+                    .expect("Unable to write stream key to hash file");
+                return key;
             }
         }
-        return match fs::read_to_string("hash") {
+        match fs::read_to_string("hash") {
             Err(_) => {
                 let stream_key = generate_stream_key();
                 warn!("Could not read stream key. Re-generating...");

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -236,7 +236,8 @@ async fn handle_command(
                 (Some(key), Some(_channel_id)) => {
                     //decode the client hash
                     let client_hash = hex::decode(key).expect("error with hash decode");
-                    let key = hmac::Key::new(hmac::HMAC_SHA512, &read_stream_key(false));
+                    let key = hmac::Key::new(hmac::HMAC_SHA512,
+                                             &read_stream_key(false, Some("")));
                     //compare the two hashes to ensure they match
                     match hmac::verify(
                         &key,
@@ -380,32 +381,38 @@ fn print_stream_key(stream_key: Vec<u8>) {
     );
 }
 
-pub fn read_stream_key(startup: bool) -> Vec<u8> {
+pub fn read_stream_key(startup: bool, stream_key_env: Option<&str>) -> Vec<u8> {
     if startup {
-        match fs::read_to_string("hash") {
+        if !stream_key_env.is_none() {
+            let stream_key = stream_key_env.unwrap().to_string();
+            if !stream_key.is_empty() {
+                let key = stream_key.as_bytes().to_vec();
+                print_stream_key(key.to_vec());
+                fs::write("hash", hex::encode(&stream_key)).expect("Unable to write file");
+                return key
+            }
+        }
+        return match fs::read_to_string("hash") {
             Err(_) => {
                 let stream_key = generate_stream_key();
                 warn!("Could not read stream key. Re-generating...");
                 print_stream_key(stream_key.to_vec());
-
                 stream_key
             }
             Ok(file) => {
                 info!("Loading existing stream key...");
-
-                let _ = match hex::decode(file) {
+                match hex::decode(file) {
                     Err(_) => {
                         let stream_key = generate_stream_key();
                         warn!("Error decoding stream key. Re-generating...");
                         print_stream_key(stream_key.to_vec());
-
-                        return stream_key;
+                        stream_key
                     }
                     Ok(stream_key) => {
                         print_stream_key(stream_key.to_vec());
-                        return stream_key;
+                        stream_key
                     }
-                };
+                }
             }
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let _ = CombinedLogger::init(loggers);
 
-    let _ = connection::read_stream_key(true);
+    let stream_key_env = matches.value_of("stream-key");
+    let _ = connection::read_stream_key(true, stream_key_env);
     info!("Listening on {}:8084", bind_address);
     let listener = TcpListener::bind(format!("{}:8084", bind_address)).await?;
 


### PR DESCRIPTION
Let's us hardcode a stream key that won't change so it can survive docker restarts.

**ISSUE: Why does the key get prefixed with `77-`?** Example:

```
# docker run -it lightspeed-ingest:latest bash
$ STREAM_KEY=test lightspeed-ingest 
05:37:18 [ INFO] Your stream key is: 77-test
05:37:19 [ INFO] Listening on 0.0.0.0:8084
```