### PR TITLE
fixed the response string for the udp port

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -148,10 +148,9 @@ impl Connection {
                         //TODO: Determine what needs to happen here
                     }
                     //this command is where we tell the client what port to use
-                    //WARNING: This command does not work properly.
-                    //For some reason the client does not like the port we are sending and defaults to 65535 this is fine for now but will be fixed in the future
+                    //TODO: make configurable?
                     Some(FtlCommand::Dot) => {
-                        let resp_string = "200 hi. Use UDP port 65535\n".to_string();
+                        let resp_string = "200. Use UDP port 65535\n".to_string();
                         let mut resp = Vec::new();
                         resp.push(resp_string);
                         //tell the frame task to send our response


### PR DESCRIPTION
The client should now accept the given port. Information about the command taken from [here](https://hayden.fyi/posts/2020-08-03-Faster-Than-Light-protocol-engineering-notes.html).
